### PR TITLE
Workaround for Ubuntu/Fedora sudo failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -76,11 +76,14 @@ runs:
         pip3 install podman-compose
         podman-compose -f CONFIG_DIR/compose.yml up -d
 
+    - name: Ensure '/ect/shadow' is readable
+      shell: bash
+      run: ansible -i CONFIG_DIR/inventory.yml -m "ansible.builtin.shell" -a "chmod u+r /etc/shadow" -vvvv all
+
     - name: Deploy cluster
       shell: bash
       run: |
         ansible-galaxy collection install -r CONFIG_DIR/requirements.yml
-        sed -i 's/become: .*$/become: false/' CONFIG_DIR/playbooks/install-cluster.yml
         ansible-playbook -i CONFIG_DIR/inventory.yml CONFIG_DIR/playbooks/install-cluster.yml
 
     - name: Install Ansible collections


### PR DESCRIPTION
When running Fedora containers in Github Ubuntu 24.04 runners, 'sudo' fails due to an authentication error. The issue seems to be due to /ect/shadow, on Fedora side, not being readable by the root user.

On Fedora, there are extended attributes on this file, which doesn't seem to be present, when running as a container under Ubuntu 24.04.

This patch adds a workaround that sets '/etc/shadow' to be readable by the 'root' user, allowing Ansible to run tasks with 'become: true'.